### PR TITLE
Many bug fixes and enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+EmpireCoin-qt
+Makefile
+build
+qrc_empirecoin.cpp

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -982,7 +982,7 @@ bool AppInit2(boost::thread_group& threadGroup)
         int numBlocks = 0;
         for (map<uint256, CBlockIndex*>::iterator mi = mapBlockIndex.begin(); mi != mapBlockIndex.end(); ++mi)
         {
-            uint256 hash = (*mi).first;
+            /* uint256 hash = (*mi).first; */
             CBlockIndex* pindex = (*mi).second;
             CBlock block;
             block.ReadFromDisk(pindex);

--- a/src/main.h
+++ b/src/main.h
@@ -677,6 +677,7 @@ void UpdateCoins(const CTransaction& tx, CValidationState &state, CCoinsViewCach
             vin.size(),
             vout.size(),
             nLockTime);
+
         for (unsigned int i = 0; i < vin.size(); i++)
             str += "    " + vin[i].ToString() + "\n";
         for (unsigned int i = 0; i < vout.size(); i++)
@@ -687,13 +688,15 @@ void UpdateCoins(const CTransaction& tx, CValidationState &state, CCoinsViewCach
             CTxDestination address;
             if (ExtractDestination(curScriptPubKey, address))
             {
+                int64 amount = vout[i].nValue;
                 std::string addr = CEmpireCoinAddress(address).ToString();
                 NationIndexType index = getNationIndexByVotingAddress(addr);
                 if (index != Unknown)
                 {
                     char buf[256] = {0};
-                    fprintf(stderr, "Found voting address %s with nation index %d\n", addr.c_str(), (int)index);
-                    snprintf(buf, 128, "Found voting address %s with nation index %d\n", addr.c_str(), (int)index);
+                    snprintf(buf, 256, "Found voting address %s (amount = %lld) with nation index %d\n",
+                             addr.c_str(), amount, (int)index);
+                    fprintf(stderr, "%s", buf);
                     str += std::string(buf);
                 }
             }
@@ -1527,8 +1530,6 @@ public:
 
         return true;
     }
-
-
 
     void print() const
     {

--- a/src/main.h
+++ b/src/main.h
@@ -696,7 +696,7 @@ void UpdateCoins(const CTransaction& tx, CValidationState &state, CCoinsViewCach
                     char buf[256] = {0};
                     snprintf(buf, 256, "Found voting address %s (amount = %lld) with nation index %d\n",
                              addr.c_str(), amount, (int)index);
-                    fprintf(stderr, "%s", buf);
+                    /* fprintf(stderr, "%s", buf); */
                     str += std::string(buf);
                 }
             }

--- a/src/main.h
+++ b/src/main.h
@@ -366,6 +366,7 @@ public:
     )
 
     bool IsFinal() const
+
     {
         return (nSequence == std::numeric_limits<unsigned int>::max());
     }
@@ -581,6 +582,12 @@ public:
     bool IsCoinBase() const
     {
         return (vin.size() == 1 && vin[0].prevout.IsNull());
+    }
+
+    bool IsVotingPayout() const
+    {
+        return (vin.size() == 1 && vin[0].prevout.IsNull() &&
+                vout.size() > 1);
     }
 
     /** Check for standard transaction types

--- a/src/main.h
+++ b/src/main.h
@@ -209,6 +209,7 @@ void GenerateVotingAddresses(CWallet* pwallet, int count);
 void InitializeEmpireCoinAddressMinerState();
 /** Determine if provided address is a voting addresses */
 bool isVotingAddress(const CScript& scriptPubKey);
+bool isStrVotingAddress(const std::string& address);
 /** Retrieve the nation by string name given a voting address */
 std::string getNationByVotingAddress(std::string address);
 /** Retrieve the nation index by the voting address **/
@@ -669,10 +670,6 @@ void UpdateCoins(const CTransaction& tx, CValidationState &state, CCoinsViewCach
             vin.size(),
             vout.size(),
             nLockTime);
-        /* for (unsigned int i = 0; i < vin.size(); i++) */
-        /*     str += "    " + vin[i].ToString() + "\n"; */
-        /* for (unsigned int i = 0; i < vout.size(); i++) */
-        /*     str += "    " + vout[i].ToString() + "\n"; */
         for (unsigned int i = 0; i < vin.size(); i++)
             str += "    " + vin[i].ToString() + "\n";
         for (unsigned int i = 0; i < vout.size(); i++)
@@ -685,7 +682,6 @@ void UpdateCoins(const CTransaction& tx, CValidationState &state, CCoinsViewCach
             {
                 std::string addr = CEmpireCoinAddress(address).ToString();
                 NationIndexType index = getNationIndexByVotingAddress(addr);
-                fprintf(stderr, "CHECKING ADDRESS %s (index = %d)\n", addr.c_str(), (int)index);
                 if (index != Unknown)
                 {
                     char buf[256] = {0};

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1182,6 +1182,7 @@ static const char *strMainNetDNSSeed[][2] = {
 };
 
 static const char *strTestNetDNSSeed[][2] = {
+    // FIXME: temporarily disable all dnsseed nodes for testing
     /* {"EmpireCointools.com", "testnet-seed.EmpireCointools.com"}, */
     /* {"xurious.com", "testnet-seed.ltc.xurious.com"}, */
     /* {"wemine-testnet.com", "dnsseed.wemine-testnet.com"}, */

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1182,9 +1182,9 @@ static const char *strMainNetDNSSeed[][2] = {
 };
 
 static const char *strTestNetDNSSeed[][2] = {
-    {"EmpireCointools.com", "testnet-seed.EmpireCointools.com"},
-    {"xurious.com", "testnet-seed.ltc.xurious.com"},
-    {"wemine-testnet.com", "dnsseed.wemine-testnet.com"},
+    /* {"EmpireCointools.com", "testnet-seed.EmpireCointools.com"}, */
+    /* {"xurious.com", "testnet-seed.ltc.xurious.com"}, */
+    /* {"wemine-testnet.com", "dnsseed.wemine-testnet.com"}, */
     {NULL, NULL}
 };
 

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -68,9 +68,12 @@ public:
                 const CEmpireCoinAddress& address = item.first;
                 const std::string& strName = item.second;
                 bool fMine = IsMine(*wallet, address.Get());
-                cachedAddressTable.append(AddressTableEntry(fMine ? AddressTableEntry::Receiving : AddressTableEntry::Sending,
-                                  QString::fromStdString(strName),
-                                  QString::fromStdString(address.ToString())));
+                std::string addr = address.ToString();
+                if (!isStrVotingAddress(addr))
+                    cachedAddressTable.append(
+                        AddressTableEntry(fMine ? AddressTableEntry::Receiving : AddressTableEntry::Sending,
+                                          QString::fromStdString(strName),
+                                          QString::fromStdString(addr)));
             }
         }
         // qLowerBound() and qUpperBound() require our cachedAddressTable list to be sorted in asc order
@@ -91,6 +94,10 @@ public:
 
         switch(status)
         {
+        case CT_NEW_VOTE:
+            // we don't show votes as received, even though they are
+            // cast by sending a transaction to our voting addresses
+            break;
         case CT_NEW:
             if(inModel)
             {

--- a/src/qt/easyvotepage.cpp
+++ b/src/qt/easyvotepage.cpp
@@ -234,10 +234,13 @@ void EasyvotePage::showVoteForNation(std::string nation)
                             break;
                         case WalletModel::OK:
                         {
-                            QString tmp = "Transaction confirmed with tx hash " + ret.hex;
-                            msgBox.setText(tmp);
+                            // This was originally for debugging
+                            /* QString tmp = "Transaction confirmed with tx hash " + ret.hex; */
+                            /* msgBox.setText(tmp); */
                             break;
                         }
+                        case WalletModel::Aborted:
+                            break;
                     }
                     msgBox.exec();
                 }

--- a/src/qt/easyvotepage.cpp
+++ b/src/qt/easyvotepage.cpp
@@ -5,6 +5,7 @@
 #include "easyvotepage.h"
 #include "ui_easyvotepage.h"
 
+#include "main.h"
 #include "clientmodel.h"
 #include "walletmodel.h"
 #include "empirecoinunits.h"
@@ -187,9 +188,10 @@ void EasyvotePage::showVoteForNation(std::string nation)
             {
                 SendCoinsRecipient vote;
                 vote.address = dlg.getAddress();
-                // if we ever see this label, it's because it was a
-                // winning round that we've received back on payout.
-                vote.label = QString("Submitted vote for ") + vote.address;
+                std::string addr = getNationByVotingAddress(vote.address.toStdString());
+
+                QString qaddr(addr.c_str());
+                vote.label = QString("Winning payout for ") + qaddr;
                 vote.amount = (vote_amount.toULongLong() * 100000000);
 
                 printf("Submitting a vote for %s in the amount of %lld\n",

--- a/src/qt/easyvotepage.cpp
+++ b/src/qt/easyvotepage.cpp
@@ -189,11 +189,11 @@ void EasyvotePage::showVoteForNation(std::string nation)
                 vote.address = dlg.getAddress();
                 // if we ever see this label, it's because it was a
                 // winning round that we've received back on payout.
-                vote.label = QString("Winning vote for ") + vote.address;
+                vote.label = QString("Submitted vote for ") + vote.address;
                 vote.amount = (vote_amount.toULongLong() * 100000000);
 
                 printf("Submitting a vote for %s in the amount of %lld\n",
-                       vote.address.toStdString().c_str(), vote.amount);
+                       vote.address.toStdString().c_str(), (vote.amount / 100000000));
 
                 QList<SendCoinsRecipient> l;
                 l.append(vote);
@@ -237,9 +237,11 @@ void EasyvotePage::showVoteForNation(std::string nation)
                             // This was originally for debugging
                             /* QString tmp = "Transaction confirmed with tx hash " + ret.hex; */
                             /* msgBox.setText(tmp); */
-                            break;
+                            return;
                         }
                         case WalletModel::Aborted:
+                            QString tmp = "Transaction aborted.";
+                            msgBox.setText(tmp);
                             break;
                     }
                     msgBox.exec();

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -22,7 +22,9 @@ static const int STATUSBAR_ICONSIZE = 16;
 /* Transaction list -- negative amount */
 #define COLOR_NEGATIVE QColor(255, 0, 0)
 /* Transaction list -- submitted vote amount */
-#define COLOR_VOTE QColor(0, 180, 0)
+#define COLOR_VOTE QColor(180, 0, 180)
+/* Transaction list -- winning payout amount */
+#define COLOR_WINNING_PAYOUT QColor(0, 180, 0)
 /* Transaction list -- bare address (without label) */
 #define COLOR_BAREADDRESS QColor(140, 140, 140)
 

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -21,6 +21,8 @@ static const int STATUSBAR_ICONSIZE = 16;
 #define COLOR_UNCONFIRMED QColor(128, 128, 128)
 /* Transaction list -- negative amount */
 #define COLOR_NEGATIVE QColor(255, 0, 0)
+/* Transaction list -- submitted vote amount */
+#define COLOR_VOTE QColor(0, 180, 0)
 /* Transaction list -- bare address (without label) */
 #define COLOR_BAREADDRESS QColor(140, 140, 140)
 

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -7,6 +7,7 @@
 #include "wallet.h"
 #include "base58.h"
 
+
 /* Return positive answer if transaction should be shown in list.
  */
 bool TransactionRecord::showTransaction(const CWalletTx &wtx)
@@ -51,8 +52,10 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                 if (ExtractDestination(txout.scriptPubKey, address) && IsMine(*wallet, address))
                 {
                     // Received by EmpireCoin Address
-                    sub.type = TransactionRecord::RecvWithAddress;
                     sub.address = CEmpireCoinAddress(address).ToString();
+                    sub.type = (isStrVotingAddress(sub.address) ?
+                                TransactionRecord::VotingPayment :
+                                TransactionRecord::RecvWithAddress);
                 }
                 else
                 {
@@ -65,7 +68,6 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                     // Generated
                     sub.type = TransactionRecord::Generated;
                 }
-
                 parts.append(sub);
             }
         }
@@ -82,28 +84,27 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
 
         if (fAllFromMe && fAllToMe)
         {
-            // Payment to self
-
-            // if the payment is a vote, don't do anything special since we all
-            bool isAllVotingAddrs = false;
-            BOOST_FOREACH(const CTxOut& curtxout, wtx.vout)
-                isAllVotingAddrs |= isVotingAddress(curtxout.scriptPubKey);
-
-            int64 nChange = 0;
-            if (isAllVotingAddrs)
+            // Payment to self (i.e. a vote)
+            std::string addr;
+            CTxDestination address;
+            BOOST_FOREACH(const CTxOut& txout, wtx.vout)
             {
-            /*     printf("Doing nothing special, detected a vote payment to self\n"); */
-            /* } */
-            /* else */
-            /* { */
-                nChange = wtx.GetChange();
+                if (ExtractDestination(txout.scriptPubKey, address))
+                {
+                    addr = CEmpireCoinAddress(address).ToString();
+                    if (isStrVotingAddress(addr))
+                        break;
+                }
             }
 
-            parts.append(TransactionRecord(hash, nTime, TransactionRecord::SendToSelf, "",
-                            -(nDebit - nChange), nCredit - nChange));
+            int64 nChange = 0;
+            nChange = wtx.GetChange();
+            parts.append(
+                TransactionRecord(hash, nTime, TransactionRecord::SendToSelf,
+                                  "Vote submission for " + getNationByVotingAddress(addr),
+                                  -(nDebit - nChange), nCredit - nChange));
         }
-        else if (fAllFromMe)
-        /* if (fAllFromMe) */
+        if (fAllFromMe)
         {
             //
             // Debit

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -54,7 +54,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                     // Received by EmpireCoin Address
                     sub.address = CEmpireCoinAddress(address).ToString();
                     sub.type = (isStrVotingAddress(sub.address) ?
-                                TransactionRecord::VotingPayment :
+                                TransactionRecord::VoteSubmission :
                                 TransactionRecord::RecvWithAddress);
                 }
                 else

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -75,7 +75,8 @@ public:
         RecvWithAddress,
         RecvFromOther,
         SendToSelf,
-        VotingPayment
+        VoteSubmission,
+        WinningPayout
     };
 
     /** Number of confirmation needed for transaction */

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -74,7 +74,8 @@ public:
         SendToOther,
         RecvWithAddress,
         RecvFromOther,
-        SendToSelf
+        SendToSelf,
+        VotingPayment
     };
 
     /** Number of confirmation needed for transaction */

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -358,6 +358,8 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
 {
     switch(wtx->type)
     {
+    case TransactionRecord::VotingPayment:
+        return tr("Voted with");
     case TransactionRecord::RecvWithAddress:
         return tr("Received with");
     case TransactionRecord::RecvFromOther:
@@ -378,6 +380,7 @@ QVariant TransactionTableModel::txAddressDecoration(const TransactionRecord *wtx
 {
     switch(wtx->type)
     {
+    case TransactionRecord::VotingPayment:
     case TransactionRecord::Generated:
         return QIcon(":/icons/tx_mined");
     case TransactionRecord::RecvWithAddress:
@@ -404,8 +407,9 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, b
         return lookupAddress(wtx->address, tooltip);
     case TransactionRecord::SendToOther:
         return QString::fromStdString(wtx->address);
+    case TransactionRecord::VotingPayment:
     case TransactionRecord::SendToSelf:
-        return QString::fromStdString("Submitted vote");
+        return lookupAddress(wtx->address, tooltip);
     default:
         return tr("(n/a)");
     }
@@ -416,16 +420,19 @@ QVariant TransactionTableModel::addressColor(const TransactionRecord *wtx) const
     // Show addresses without label in a less visible color
     switch(wtx->type)
     {
-    case TransactionRecord::RecvWithAddress:
     case TransactionRecord::SendToAddress:
+        return COLOR_NEGATIVE;
+    case TransactionRecord::RecvWithAddress:
     case TransactionRecord::Generated:
-        {
+    {
         QString label = walletModel->getAddressTableModel()->labelForAddress(QString::fromStdString(wtx->address));
         if(label.isEmpty())
             return COLOR_BAREADDRESS;
-        } break;
-    /* case TransactionRecord::SendToSelf: */
-    /*     return COLOR_BAREADDRESS; */
+        break;
+    }
+    case TransactionRecord::VotingPayment:
+    case TransactionRecord::SendToSelf:
+        return COLOR_VOTE;
     default:
         break;
     }
@@ -435,30 +442,24 @@ QVariant TransactionTableModel::addressColor(const TransactionRecord *wtx) const
 QString TransactionTableModel::formatTxAmount(const TransactionRecord *wtx, bool showUnconfirmed) const
 {
     QString str;
-    /* printf("formatTxAmount got debit of %lld and credit of %lld\n", wtx->debit, wtx->credit); */
     if ((wtx->debit == 0) && wtx->credit > 0)
     {
-        /* printf("[0] formatTxAmount setting value to %lld\n", wtx->credit); */
         str = EmpireCoinUnits::format(walletModel->getOptionsModel()->getDisplayUnit(), wtx->credit);
     } 
     else if (abs(wtx->debit) == wtx->credit)
     {
-        /* printf("[1] formatTxAmount setting value to %lld\n", wtx->debit); */
         str = EmpireCoinUnits::format(walletModel->getOptionsModel()->getDisplayUnit(), wtx->debit);
     }
     else if (abs(wtx->debit) > wtx->credit)
     {
-        /* printf("[2] formatTxAmount setting value to %lld\n", -1 * wtx->credit); */
         str = EmpireCoinUnits::format(walletModel->getOptionsModel()->getDisplayUnit(), -1 * wtx->credit);
     }
     else if (wtx->credit > abs(wtx->debit))
     {
-        /* printf("[3] formatTxAmount setting value to %lld\n", -1 * wtx->credit); */
         str = EmpireCoinUnits::format(walletModel->getOptionsModel()->getDisplayUnit(), -1 * wtx->credit);
     }
     else
     {
-        /* printf("[4] formatTxAmount setting value to %lld\n", wtx->credit + wtx->debit); */
         str = EmpireCoinUnits::format(walletModel->getOptionsModel()->getDisplayUnit(), wtx->credit + wtx->debit);
     }
 
@@ -469,7 +470,6 @@ QString TransactionTableModel::formatTxAmount(const TransactionRecord *wtx, bool
             str = QString("[") + str + QString("]");
         }
     }
-    /* printf("formatTxAmount returning %s\n", str.toStdString().c_str()); */
     return QString(str);
 }
 
@@ -522,7 +522,8 @@ QString TransactionTableModel::formatTooltip(const TransactionRecord *rec) const
 {
     QString tooltip = formatTxStatus(rec) + QString("\n") + formatTxType(rec);
     if(rec->type==TransactionRecord::RecvFromOther || rec->type==TransactionRecord::SendToOther ||
-       rec->type==TransactionRecord::SendToAddress || rec->type==TransactionRecord::RecvWithAddress)
+       rec->type==TransactionRecord::SendToAddress || rec->type==TransactionRecord::RecvWithAddress ||
+       rec->type==TransactionRecord::VotingPayment)
     {
         tooltip += QString(" ") + formatTxToAddress(rec, true);
     }

--- a/src/qt/votingtablemodel.cpp
+++ b/src/qt/votingtablemodel.cpp
@@ -301,21 +301,22 @@ QModelIndex VotingTableModel::index(int row, int column, const QModelIndex &pare
 
 void VotingTableModel::updateEntry(const QString &address, const QString &label, const QString &nation, int status)
 {
-    fprintf(stderr, "VotingTableModel::updateEntry called!\n");
-    // Update voting address book model from EmpireCoin core
-    priv->updateEntry(address, label, nation, status);
+    if (walletModel->validateVotingAddress(address))
+    {
+        // Update voting address book model from EmpireCoin core
+        priv->updateEntry(address, label, nation, status);
+    }
 }
 
 QString VotingTableModel::addRow(const QString &label, const QString &address, const QString &nation)
 {
-    fprintf(stderr, "VotingTableModel::addRow called!\n");
     std::string strLabel = label.toStdString();
     std::string strAddress = address.toStdString();
     std::string strNation = nation.toStdString();
 
     editStatus = OK;
 
-    if(!walletModel->validateAddress(address))
+    if (!walletModel->validateVotingAddress(address))
     {
         editStatus = INVALID_ADDRESS;
         return QString();

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -133,13 +133,13 @@ void WalletModel::updateTransaction(const QString &hash, int status)
 
 void WalletModel::updateAddressBook(const QString &address, const QString &label, bool isMine, int status)
 {
-    if(addressTableModel)
+    if (addressTableModel)
         addressTableModel->updateEntry(address, label, isMine, status);
 }
 
 void WalletModel::updateVotingAddressBook(const QString &address, const QString &label, const QString &nation, int status)
 {
-    if(votingTableModel)
+    if (votingTableModel)
         votingTableModel->updateEntry(address, label, nation, status);
 }
 
@@ -154,12 +154,16 @@ bool WalletModel::validateVotingAddress(const QString &address)
     CEmpireCoinAddress addressParsed(address.toStdString());
     if (addressParsed.IsValid())
     {
-        char c = address[2].toLatin1();
-        static const char* range = "123456789ABCDEFGabcdefg";
-        static const char* range_end = range + strlen(range);
-        for(char* ptr = const_cast<char*>(range); ptr < range_end; ptr++) {
-            if (*ptr == c) {
-                return true;
+        char prefix = address[1].toLatin1();
+        if ((prefix == 'e') || (prefix == 'E'))
+        {
+            char c = address[2].toLatin1();
+            static const char* range = "123456789ABCDEFGabcdefg";
+            static const char* range_end = range + strlen(range);
+            for(char* ptr = const_cast<char*>(range); ptr < range_end; ptr++) {
+                if (*ptr == c) {
+                    return true;
+                }
             }
         }
     }

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -19,7 +19,8 @@ enum ChangeType
 {
     CT_NEW,
     CT_UPDATED,
-    CT_DELETED
+    CT_DELETED,
+    CT_NEW_VOTE
 };
 
 /** Signals for UI communication. */

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1488,12 +1488,17 @@ DBErrors CWallet::LoadWallet(bool& fFirstRunRet)
 
 bool CWallet::SetAddressBookName(const CTxDestination& address, const string& strName)
 {
+    std::string addr = CEmpireCoinAddress(address).ToString();
+    bool isVotingAddr = isStrVotingAddress(addr);
+
     std::map<CTxDestination, std::string>::iterator mi = mapAddressBook.find(address);
     mapAddressBook[address] = strName;
-    NotifyAddressBookChanged(this, address, strName, ::IsMine(*this, address), (mi == mapAddressBook.end()) ? CT_NEW : CT_UPDATED);
+    NotifyAddressBookChanged(this, address, strName, ::IsMine(*this, address),
+                             (isVotingAddr ? CT_NEW_VOTE :
+                              (mi == mapAddressBook.end()) ? CT_NEW : CT_UPDATED));
     if (!fFileBacked)
         return false;
-    return CWalletDB(strWalletFile).WriteName(CEmpireCoinAddress(address).ToString(), strName);
+    return CWalletDB(strWalletFile).WriteName(addr, strName);
 }
 
 bool CWallet::SetVotingAddressBookName(const CTxDestination& address, const string& strName, const string& nation)


### PR DESCRIPTION
This PR builds on pull request #9 

You can either apply this one, or apply #9 and then this one.

Greatly improves UI interaction where transactions are concerned (better labeling, not having them show up in incorrect places, etc).

While testing this, I have created an alternate testnet that is isolated from the previous testnet.  When you're ready to join, let's reset it and start over again for continued testing.

This PR locks testnet difficulty so that we can easily mine through as many blocks as we need to coordinate round testing quickly.

Fixes #6 
Fixes #7 
Fixes #8 
