### PR TITLE
Adds new RPC call "getnewvotingaddress"

### DIFF
--- a/src/empirecoinrpc.cpp
+++ b/src/empirecoinrpc.cpp
@@ -214,6 +214,7 @@ static const CRPCCommand vRPCCommands[] =
     { "getinfo",                &getinfo,                true,      false,      false },
     { "getmininginfo",          &getmininginfo,          true,      false,      false },
     { "getnewaddress",          &getnewaddress,          true,      false,      true },
+    { "getnewvotingaddress",    &getnewvotingaddress,    true,      false,      true },
     { "getaccountaddress",      &getaccountaddress,      true,      false,      true },
     { "setaccount",             &setaccount,             true,      false,      true },
     { "getaccount",             &getaccount,             false,     false,      true },

--- a/src/empirecoinrpc.h
+++ b/src/empirecoinrpc.h
@@ -154,6 +154,7 @@ extern json_spirit::Value getblocktemplate(const json_spirit::Array& params, boo
 extern json_spirit::Value submitblock(const json_spirit::Array& params, bool fHelp);
 
 extern json_spirit::Value getnewaddress(const json_spirit::Array& params, bool fHelp); // in rpcwallet.cpp
+extern json_spirit::Value getnewvotingaddress(const json_spirit::Array& params, bool fHelp); // in rpcwallet.cpp
 extern json_spirit::Value getaccountaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value setaccount(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getaccount(const json_spirit::Array& params, bool fHelp);

--- a/src/main.h
+++ b/src/main.h
@@ -207,6 +207,7 @@ bool AbortNode(const std::string &msg);
 /** Generate voting addresses */
 void GenerateVotingAddresses(CWallet* pwallet, int count);
 void InitializeEmpireCoinAddressMinerState();
+CPubKey GenerateSingleVotingAddress(CWallet* pwallet, NationIndexType nation);
 /** Determine if provided address is a voting addresses */
 bool isVotingAddress(const CScript& scriptPubKey);
 bool isStrVotingAddress(const std::string& address);
@@ -214,6 +215,7 @@ bool isStrVotingAddress(const std::string& address);
 std::string getNationByVotingAddress(std::string address);
 /** Retrieve the nation index by the voting address **/
 NationIndexType getNationIndexByVotingAddress(std::string address);
+NationIndexType getNationIndexByNation(std::string nation);
 
 bool GetWalletFile(CWallet* pwallet, std::string &strWalletFileOut);
 

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -125,7 +125,6 @@ Value setgenerate(const Array& params, bool fHelp)
     return Value::null;
 }
 
-
 Value gethashespersec(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -125,6 +125,24 @@ Value getnewaddress(const Array& params, bool fHelp)
     return CEmpireCoinAddress(keyID).ToString();
 }
 
+Value getnewvotingaddress(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 1)
+        throw runtime_error(
+            "getnewvotingaddress nation\n"
+            "Returns a new EmpireCoin voting address for a specified nation.  "
+            "When the key for the specified nation is generated, it is added "
+            "to the wallet it was generated in.");
+
+    NationIndexType nation = getNationIndexByNation(params[0].get_str());
+    if (nation == Unknown)
+        throw runtime_error("Invalid nation specfied.");
+    
+    // Generate a new voting key that is added to wallet
+    CPubKey newKey = GenerateSingleVotingAddress(pwalletMain, nation);
+    return CEmpireCoinAddress(newKey.GetID()).ToString();
+}
+
 
 CEmpireCoinAddress GetAccountAddress(string strAccount, bool bForceNew=false)
 {

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -48,6 +48,20 @@ CPubKey CWallet::GenerateNewKey()
     return pubkey;
 }
 
+void CWallet::GenerateNewKeyPairWithoutStoring(CPubKey& pubkey, CKey& secret)
+{
+    bool fCompressed = CanSupportFeature(FEATURE_COMPRPUBKEY); // default to compressed public keys if we want 0.6.0 wallets
+
+    RandAddSeedPerfmon();
+    secret.MakeNewKey(fCompressed);
+
+    // Compressed public keys were introduced in version 0.6.0
+    if (fCompressed)
+        SetMinVersion(FEATURE_COMPRPUBKEY);
+
+    pubkey = secret.GetPubKey();
+}
+
 bool CWallet::AddKeyPubKey(const CKey& secret, const CPubKey &pubkey)
 {
     if (!CCryptoKeyStore::AddKeyPubKey(secret, pubkey))

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -139,6 +139,8 @@ public:
     // keystore implementation
     // Generate a new key
     CPubKey GenerateNewKey();
+    // Generate a new voting address (not saved in the store)
+    void GenerateNewKeyPairWithoutStoring(CPubKey& pubkey, CKey& secret);
     // Adds a key to the store, and saves it to disk.
     bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey);
     // Adds a key to the store, without saving it to disk (used by LoadWallet)


### PR DESCRIPTION
- adds a threaded implementation of the address miner for generating a single voting address that only stores the final resulting keypair to the wallet store
- uses above method for new rpc command getnewvotingaddress that generates a voting address for a specified nation

Fixes #14
Fixes #16 
